### PR TITLE
Expose supported

### DIFF
--- a/lib/webrtc.js
+++ b/lib/webrtc.js
@@ -211,3 +211,4 @@ function validateOptions(options) {
  * @exports
  */
 module.exports = WebRTC;
+module.exports.supported = supported;


### PR DESCRIPTION
add supported flag so you can check browser compatibility before creating a new instance of the widget.
