### PR TITLE
Inline css no being added to user-list when using listContainer option

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -95,15 +95,10 @@ View.prototype.initialize = function() {
   this._addAllUsers();
 
   if (this._listContainer) {
-    this._wrapper.style.position = 'absolute';
-    this._collapseWrapper.style.display = 'none';
-
     this._listContainer.appendChild(this._wrapper);
-
-    return;
+  } else {
+    document.body.appendChild(this._wrapper);
   }
-
-  document.body.appendChild(this._wrapper);
 };
 
 View.prototype._addAllUsers = function() {


### PR DESCRIPTION
I ran into an issue when using your widget, due to the fact that, when using the optional parameter listContainer to specify a custom position for the list, it for some reason adds two inline CSS properties.

I understand they were possibly needed somewhere, but as it stands, they are difficult to override, since they're being inlined directly in the DOM
