### PR TITLE
Specify list container styles with a class

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -95,7 +95,9 @@ View.prototype.initialize = function() {
   this._addAllUsers();
 
   if (this._listContainer) {
+    classes(this._wrapper).add(COMMON.CUSTOM_CONTAINER_CLASS);
     this._listContainer.appendChild(this._wrapper);
+
   } else {
     document.body.appendChild(this._wrapper);
   }

--- a/webrtc.css
+++ b/webrtc.css
@@ -404,6 +404,17 @@
 }
 
 /*
+   Custom List Container
+   =========================================================================== */
+.gi-webrtc.gi-custom-container {
+  position: absolute;
+}
+
+.gi-webrtc.gi-custom-container .gi-collapse-wrapper {
+  display: none;
+}
+
+/*
    Collapse Toggle
    ========================================================================== */
 


### PR DESCRIPTION
Add a `gi-custom-container` class to the wrapper for applying the default styles to the user list.

These styles can be overridden like so:

``` css
.gi-webrtc.gi-override.gi-custom-container {
  position: relative;
}

.gi-webrtc.gi-override .gi-collapse-wrapper {
  display: block;
}
```
